### PR TITLE
Allow to create new PDB from an existing pdb file instead of pdbseed

### DIFF
--- a/createDatabase
+++ b/createDatabase
@@ -27,19 +27,45 @@ set -Eeuo pipefail
 NEW_PDB="${1:-}"
 
 if [ -n "${NEW_PDB}" ]; then
+  if [ -f "${ORACLE_BASE}/${NEW_PDB}.pdb" ]; then
+    echo "Plugging existing pluggable database ${NEW_PDB} from ${ORACLE_BASE}/${NEW_PDB}.pdb"
 
-  RANDOM_PDBADIN_PASSWORD=$(date +%s | sha256sum | base64 | head -c 8)
+    sqlplus -s / as sysdba <<EOF
+       -- Exit on any errors
+       WHENEVER SQLERROR EXIT SQL.SQLCODE
+
+       CREATE PLUGGABLE DATABASE ${NEW_PDB} \
+        USING '${ORACLE_BASE}/${NEW_PDB}.pdb' COPY \
+         FILE_NAME_CONVERT=('$ORACLE_BASE','${ORACLE_BASE}/oradata/${ORACLE_SID}/${NEW_PDB}');
+
+       exit;
+EOF
+
+    # remove pdb file same as FREE.7z is removed after initialization
+    rm -v "${ORACLE_BASE}/${NEW_PDB}.pdb"
+  else
+    echo "Creating new pluggable database ${NEW_PDB}"
+
+    RANDOM_PDBADIN_PASSWORD=$(date +%s | sha256sum | base64 | head -c 8)
+    sqlplus -s / as sysdba <<EOF
+       -- Exit on any errors
+       WHENEVER SQLERROR EXIT SQL.SQLCODE
+
+       CREATE PLUGGABLE DATABASE ${NEW_PDB} \
+        ADMIN USER PDBADMIN IDENTIFIED BY "${RANDOM_PDBADIN_PASSWORD}" \
+         FILE_NAME_CONVERT=('pdbseed','${NEW_PDB}') \
+          DEFAULT TABLESPACE USERS \
+           DATAFILE '${ORACLE_BASE}/oradata/${ORACLE_SID}/${NEW_PDB}/users01.dbf' \
+            SIZE 1m AUTOEXTEND ON NEXT 10m MAXSIZE UNLIMITED;
+
+       exit;
+EOF
+    unset RANDOM_PDBADIN_PASSWORD
+  fi
 
   sqlplus -s / as sysdba <<EOF
      -- Exit on any errors
      WHENEVER SQLERROR EXIT SQL.SQLCODE
-
-     CREATE PLUGGABLE DATABASE ${NEW_PDB} \
-      ADMIN USER PDBADMIN IDENTIFIED BY "${RANDOM_PDBADIN_PASSWORD}" \
-       FILE_NAME_CONVERT=('pdbseed','${NEW_PDB}') \
-        DEFAULT TABLESPACE USERS \
-         DATAFILE '${ORACLE_BASE}/oradata/${ORACLE_SID}/${NEW_PDB}/users01.dbf' \
-          SIZE 1m AUTOEXTEND ON NEXT 10m MAXSIZE UNLIMITED;
 
      -- Open PDB and save state
      ALTER PLUGGABLE DATABASE ${NEW_PDB} OPEN READ WRITE;
@@ -49,7 +75,5 @@ if [ -n "${NEW_PDB}" ]; then
      ALTER SYSTEM REGISTER;
      exit;
 EOF
-
-  unset RANDOM_PDBADIN_PASSWORD
 
 fi;


### PR DESCRIPTION
Allow to create PDB from a previously exported/unplugged `<PDB_NAME>.pdb` file instead of creating an empty PDB from `pdbseed`.

Our use-case:
1. Preparing usable database image requires importing data from dump and/or executing migration scripts (Flyway, Liquibase, etc; in-house solution in our case).  In order to save on size of a final image it's more efficient to:
   1. Export pluggable database as a single `<PDB_NAME>.pdb` file
   2. Create a custom image that `COPY` this file
   3. Have user-script(s) that creates a new pluggable database from this file during first container startup

It would be nice to have ability to just upload custom `<PDB_NAME>.pdb` file into image and instruct container to create PDB with matching name upon startup by setting `ORACLE_DATABASE` property. 

Currently an empty PDB will be created using `pdbseed` which then needs to be dropped and re-imported from `<PDB_NAME>.pdb` file in a user-script(s). This leads to a short time period in which empty PDB created from `pdbseed` can be observed by outside world as available to outside world until user-script(s) replace it with a correct one, in particular this affects container's healthcheck.

